### PR TITLE
Creating ViewPastPrograms view for Training Program. Adding code to o…

### DIFF
--- a/BangazonWorkforce/Controllers/TrainingProgramsController.cs
+++ b/BangazonWorkforce/Controllers/TrainingProgramsController.cs
@@ -68,12 +68,49 @@ namespace BangazonWorkforce.Controllers
             }
         }
 
+        //GET: TrainingProgram (Past Training Programs)
+        public ActionResult ViewPastPrograms()
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT t.Id,
+                                        t.Name,
+                                        t.StartDate,
+                                        t.EndDate,
+                                        t.MaxAttendees
+                                        FROM TrainingProgram t
+                                        WHERE t.EndDate < CURRENT_TIMESTAMP";
+                    SqlDataReader reader = cmd.ExecuteReader();
+                    List<TrainingProgram> trainingPrograms = new List<TrainingProgram>();
+
+                    while (reader.Read())
+                    {
+                        TrainingProgram trainingProgram = new TrainingProgram
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Name = reader.GetString(reader.GetOrdinal("Name")),
+                            StartDate = reader.GetDateTime(reader.GetOrdinal("StartDate")),
+                            EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
+                            MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees"))
+                        };
+                        trainingPrograms.Add(trainingProgram);
+                    }
+                    reader.Close();
+                    return View(trainingPrograms);
+                }
+            }
+        }
+
         // GET: TrainingProgram/Details/5
         public ActionResult Details(int id)
         {
             TrainingProgram trainingProgram = GetTrainingProgramById(id);
             return View(trainingProgram);
         }
+
 
         // GET: TrainingProgram/Create
         public ActionResult Create()

--- a/BangazonWorkforce/Views/TrainingPrograms/Details.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/Details.cshtml
@@ -53,6 +53,21 @@
     </dl>
 </div>
 <div>
-    @Html.ActionLink("Edit", "Edit", new { id = Model.Id }) |
-    <a asp-action="Index">Back to List</a>
+    @if (Model.EndDate < DateTime.Now)
+    {
+        <div>
+            <a asp-action="ViewPastPrograms">Back to List of Past Training Programs</a>
+        </div>
+        <div>
+            <a asp-action="Index">Back to List of All Training Programs</a>
+        </div>
+    }
+
+    @if (Model.EndDate > DateTime.Now)
+    {
+        @Html.ActionLink("Edit", "Edit", new { id = Model.Id })
+        <a asp-action="Index">Back to List</a>
+    }
+
+
 </div>

--- a/BangazonWorkforce/Views/TrainingPrograms/ViewPastPrograms.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/ViewPastPrograms.cshtml
@@ -1,19 +1,16 @@
 ﻿@* Author: Billy Mathison
-    * Purpose: Creating an index template for a training program including link to create mew training program, list of future training progrms, and link to view past training programs.
+    * Purpose: Creating a ViewPastPrograms template for a training program including link to create mew training program, list of future training progrms, and link to view past training programs.
     * Methods: None
 *@
 
 @model IEnumerable<BangazonWorkforce.Models.TrainingProgram>
 
 @{
-    ViewData["Title"] = "Index";
+    ViewData["Title"] = "ViewPastPrograms";
 }
 
-<h1>Index</h1>
+<h1>Past Training Programs</h1>
 
-<p>
-    <a asp-action="Create">Create New</a>
-</p>
 <table class="table">
     <thead>
         <tr>
@@ -49,14 +46,12 @@
                     @Html.DisplayFor(modelItem => item.MaxAttendees)
                 </td>
                 <td>
-                    @Html.ActionLink("Edit", "Edit", new { id = item.Id }) |
-                    @Html.ActionLink("Details", "Details", new { id = item.Id }) |
-                    @Html.ActionLink("Delete", "Delete", new { id = item.Id })
+                    @Html.ActionLink("Details", "Details", new { id = item.Id })
                 </td>
             </tr>
         }
     </tbody>
 </table>
-<p>
-    <a asp-action="ViewPastPrograms">View Past Training Programs</a>
-</p>
+<div>
+    <a asp-action="Index">Back to List</a>
+</div>


### PR DESCRIPTION
…nly show edit button for future programs in details view.

# Description

Adding view for past training programs. Only displaying details for each, no edit functionality.


[Fixes Issue #16](https://github.com/the-devastating-chickens/BangazonWorkforce/issues/16)

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Testing Instructions

1. `git fetch --all`
2. `git checkout bm-view-past-training-programs
3. Run BangazonWorkforce
4. Navigate to Training Programs tab. Click on View Past Training Program link at bottom of page.
5. Verify that only past training programs are in the list.
6. Click on details for any training program and verify that the details are correct.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works
